### PR TITLE
Hotfix/0.32.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flasman-plugin
-PKG_VERSION:=0.32.1
+PKG_VERSION:=0.32.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL

--- a/files/etc/uci-defaults/z002_flashbox-network.sh
+++ b/files/etc/uci-defaults/z002_flashbox-network.sh
@@ -21,7 +21,15 @@ json_get_var _lan_ipv6prefix lan_ipv6prefix
 json_get_var _enable_ipv6 enable_ipv6 
 json_close_object
 
-[ -z "$_enable_ipv6" ] && [ "$FLM_WAN_IPV6_ENABLED" = "y" ] && _enable_ipv6="1" || _enable_ipv6="0"
+if [ -z "$_enable_ipv6" ]
+then
+	if [ "$FLM_WAN_IPV6_ENABLED" = "y" ]
+	then
+		_enable_ipv6="1"
+	else
+		_enable_ipv6="0"
+	fi
+fi
 
 if [ "$_lan_addr" = "" ] || [ "$_lan_netmask" = "" ]
 then


### PR DESCRIPTION
Notas da versão 0.32.2
==================

Consertos:
- Consertamos a manutenção da opção de IPv6
habilitada após um hard reset quando o roteador
não possui cadastro no Flashman