### PR TITLE
Fixed C5 or G5 not starting 5G after changing channel

### DIFF
--- a/files/usr/share/flashman_update.sh
+++ b/files/usr/share/flashman_update.sh
@@ -466,7 +466,7 @@ bridge_fix_dns=$_local_bridge_fix_dns"
 									"$_wifi_htmode_50" "$_wifi_state_50" \
 									"$_wifi_txpower_50" "$_wifi_hidden_50" \
 									"$_mesh_mode" && _need_wifi_reload=1
-		[ $_need_wifi_reload -eq 1 ] && wifi reload && /etc/init.d/minisapo reload
+		[ $_need_wifi_reload -eq 1 ] && wifi && /etc/init.d/minisapo reload
 
 		# If in mesh as slave, update the devices in mesh
 		if [ "$_mesh_mode" -gt 1 ] && [ ! -z "$_mesh_master" ]

--- a/files/usr/share/functions/mesh_functions.sh
+++ b/files/usr/share/functions/mesh_functions.sh
@@ -566,7 +566,7 @@ update_mesh_link() {
 			set_wifi_local_config "" "" "auto" "" "" "" "" "" \
 				"" "" "$_channel_5g" "" "" "" "" "" "$_mesh_mode"
 			log "MESHLINK" "Change 5Ghz Backbone ($_channel_5g) ($_bssid_5g) ..."
-			wifi reload
+			wifi
 			sleep 5
 			# Atheros stations needs some extra time to connect and prevent a deadloop on backbone probing
 			[ -n "$(uci -q get wireless.mesh5_sta.ifname | grep ath )" ] && sleep 15
@@ -588,7 +588,7 @@ update_mesh_link() {
 			set_wifi_local_config "" "" "$_channel_2g" "" "" "" "" "" \
 				"" "" "auto" "" "" "" "" "" "$_mesh_mode"
 			log "MESHLINK" "Change 2.4Ghz Backbone ($_channel_2g) ($_bssid_2g) ..."
-			wifi reload
+			wifi
 			sleep 5
 			# Atheros stations needs some extra time to connect and prevent a deadloop on backbone probing
 			[ -n "$(uci -q get wireless.mesh2_sta.ifname | grep ath )" ] && sleep 15

--- a/files/usr/share/functions/wireless_functions.sh
+++ b/files/usr/share/functions/wireless_functions.sh
@@ -463,7 +463,7 @@ change_wifi_state() {
 	[ "$_itf_num" = "1" ] && _wifi_state=""
 	set_wifi_local_config "" "" "" "" "" "$_wifi_state" "" "" \
 					"" "" "" "" "" "$_wifi_state_50" "" "" \
-					"" && wifi reload && /etc/init.d/minisapo reload
+					"" && wifi && /etc/init.d/minisapo reload
 }
 
 set_wps_push_button() {


### PR DESCRIPTION
Changed wifi reload commands to wifi commands. wifi reload made C5 and G5 not starting up the 5G interface after changing 2.4G interface's channel configuration.