### PR TITLE
Feature/fix speedtest raw

### DIFF
--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -256,7 +256,7 @@ router_status() {
 
 	if [ -f "$_out_file" ]
 	then
-		_res=local _file_content="$(cat "$_out_file")"
+		local _file_content="$(cat "$_out_file")"
 		_res=""
 		_res=$(send_data_flashman "routerstatus" "$_file_content")
 

--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -171,11 +171,9 @@ run_ping_ondemand_test() {
 		flashbox_multi_ping "$_hosts_file" "$_out_file" "all"
 		if [ -f "$_out_file" ]
 		then
+			local _file_content="$(cat "$_out_file")"
 			_res=""
-			_res=$(cat "$_out_file" | curl -s --tlsv1.2 --connect-timeout 5 \
-						--retry 1 -H "Content-Type: application/json" \
-						-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-						--data @- "https://$FLM_SVADDR/deviceinfo/receive/pingresult")
+			_res=$(send_data_flashman "pingresult" "$_file_content")
 
 			json_load "$_res"
 			json_get_var _processed processed
@@ -254,11 +252,9 @@ router_status() {
 
 	if [ -f "$_out_file" ]
 	then
+		_res=local _file_content="$(cat "$_out_file")"
 		_res=""
-		_res=$(cat "$_out_file" | curl -s --tlsv1.2 --connect-timeout 5 \
-					--retry 1 -H "Content-Type: application/json" \
-					-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-					--data @- "https://$FLM_SVADDR/deviceinfo/receive/routerstatus")
+		_res=$(send_data_flashman "routerstatus" "$_file_content")
 
 		json_load "$_res"
 		json_get_var _processed processed
@@ -314,11 +310,9 @@ send_wan_info() {
 	json_add_string "ipv6_mask" "$_ipv6_mask"
 
 	# Send the json
+	local _json_content="$(json_dump)"
 	_res=""
-	_res=$(json_dump | curl -s --tlsv1.2 --connect-timeout 5 \
-				--retry 1 -H "Content-Type: application/json" \
-				-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-				--data @- "https://$FLM_SVADDR/deviceinfo/receive/waninfo")
+	_res=$(send_data_flashman "waninfo" "$_json_content")
 
 	json_cleanup
 
@@ -352,11 +346,9 @@ send_lan_info() {
 	json_add_string "prefix_delegation_local" "$_local_addr"
 
 	# Send the json
+	local _json_content="$(json_dump)"
 	_res=""
-	_res=$(json_dump | curl -s --tlsv1.2 --connect-timeout 5 \
-				--retry 1 -H "Content-Type: application/json" \
-				-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-				--data @- "https://$FLM_SVADDR/deviceinfo/receive/laninfo")
+	_res=$(send_data_flashman "laninfo" "$_json_content")
 
 	json_cleanup
 
@@ -587,10 +579,7 @@ get_traceroute() {
 		# Send the json
 		local _res=""
 		local _processed="0"
-		_res=$(echo "$_out_json" | curl -s --tlsv1.2 --connect-timeout 5 \
-					--retry 1 -H "Content-Type: application/json" \
-					-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-					--data @- "https://$FLM_SVADDR/deviceinfo/receive/traceroute")
+		_res=$(send_data_flashman "traceroute" "$_out_json")
 
 		# Check server response
 		if [ -n "$_res" ]
@@ -833,11 +822,10 @@ send_wps_status() {
 	then
 		log "WPS" "Sending $_wps_inform and $_wps_content to Flashman..."
 
+		local _file_content="$(cat "$_out_file")"
 		_res=""
-		_res=$(cat "$_out_file" | curl -s --tlsv1.2 --connect-timeout 5 \
-			--retry 1 -H "Content-Type: application/json" \
-			-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-			--data @- "https://$FLM_SVADDR/deviceinfo/receive/wps")
+		_res=$(send_data_flashman "wps" "$_file_content")
+
 		json_load "$_res"
 		json_get_var _processed processed
 		json_close_object
@@ -913,10 +901,7 @@ END {
 }
 	')
 
-	_res=$(echo "$_INFO" | curl -s --tlsv1.2 --connect-timeout 5 --retry 1 \
-				-H "Content-Type: application/json" \
-				-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-				--data @- "https://$FLM_SVADDR/deviceinfo/receive/sitesurvey")
+	_res=$(send_data_flashman "sitesurvey" "$_INFO")
 
 	json_cleanup
 	json_load "$_res"

--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -169,6 +169,10 @@ run_ping_ondemand_test() {
 		json_cleanup
 
 		flashbox_multi_ping "$_hosts_file" "$_out_file" "all"
+
+		# Remove file
+		rm "$_hosts_file"
+
 		if [ -f "$_out_file" ]
 		then
 			local _file_content="$(cat "$_out_file")"

--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -638,7 +638,7 @@ run_speed_ondemand_test() {
 	local _timeout="$4"
 
 	# Default reply in case of failure
-	local _reply'{"downSpeed":"","user":"'"$_username"'"}'
+	local _reply='{"downSpeed":"","user":"'"$_username"'"}'
 
 	# List to do the speedtests
 	local _urllist=""

--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -699,14 +699,14 @@ run_speed_ondemand_raw_test() {
 			_result="$(flash-measure "$_timeout" "$_connections" $_urllist)"
 			_retstatus=$?
 
+			# Restore traffic
+			log "SPEEDTESTRAW" "Restoring firewall to normal..."
+			undrop_all_forward_traffic
+
 			if [ "$_retstatus" -ne 0 ]
 			then
 				return "$_retstatus"
 			fi
-
-			# Restore traffic
-			log "SPEEDTESTRAW" "Restoring firewall to normal..."
-			undrop_all_forward_traffic
 
 			# Send the data do flashman
 			local _res=""

--- a/files/usr/share/functions/common_functions.sh
+++ b/files/usr/share/functions/common_functions.sh
@@ -175,6 +175,36 @@ rest_flashman() {
 	fi
 }
 
+# Send data to flashman using rest api with headers and json to deviceinfo
+send_data_flashman() {
+	local _url=$1
+	local _data=$2
+	local _res
+	local _curl_out
+	_res=$(curl -s \
+				-A "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)" \
+				-H "Content-Type: application/json" \
+				--tlsv1.2 --connect-timeout 5 --retry 1 \
+				-H "X-ANLIX-ID: $(get_mac)" -H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
+				--data "$_data" \
+				"https://$FLM_SVADDR/deviceinfo/receive/$_url")
+	_curl_out=$?
+
+	if [ "$_curl_out" -eq 0 ]
+	then
+		echo "$_res"
+		return 0
+	elif [ "$_curl_out" -eq 51 ]
+	then
+		# curl code 51 is bad certificate
+		return 2
+	else
+		log "REST FLASHMAN" "Error connecting to server ($_curl_out)"
+		# other curl errors
+		return 1
+	fi
+}
+
 is_authenticated() {
 	local _res
 	local _is_authenticated=1

--- a/files/usr/share/functions/common_functions.sh
+++ b/files/usr/share/functions/common_functions.sh
@@ -175,7 +175,21 @@ rest_flashman() {
 	fi
 }
 
-# Send data to flashman using rest api with headers and json to deviceinfo
+
+# send_data_flashman
+#	This function sends json data to /deviceinfo/receive/ endpoints to
+#		flashman, using rest api
+#
+# Inputs:
+#	$1 - The url to send to in the following format:
+#		-- https://$FLM_SVADDR/deviceinfo/receive/$_url
+#	$2 - The data to send
+#
+# Outputs:
+#	0 if could send data to flashman
+#	1 if could not send data to flashman with an unknown error
+#	2 if could not send data to flashman due to bad certificate
+#	log in case an error happened
 send_data_flashman() {
 	local _url=$1
 	local _data=$2
@@ -196,10 +210,11 @@ send_data_flashman() {
 		return 0
 	elif [ "$_curl_out" -eq 51 ]
 	then
+		log "SEND DATA FLASHMAN" "Error connecting to server (Bad Certificate)"
 		# curl code 51 is bad certificate
 		return 2
 	else
-		log "REST FLASHMAN" "Error connecting to server ($_curl_out)"
+		log "SEND DATA FLASHMAN" "Error connecting to server ($_curl_out)"
 		# other curl errors
 		return 1
 	fi

--- a/files/usr/share/functions/dhcp_functions.sh
+++ b/files/usr/share/functions/dhcp_functions.sh
@@ -414,11 +414,9 @@ send_online_devices() {
 	get_online_devices
 	[ "$(get_mesh_mode)" -gt 1 ] && get_online_mesh_routers
 
-	_res=$(json_dump | curl -s --tlsv1.2 --connect-timeout 5 \
-				--retry 1 -H "Content-Type: application/json" \
-				-H "X-ANLIX-ID: $(get_mac)" \
-				-H "X-ANLIX-SEC: $FLM_CLIENT_SECRET" \
-				--data @- "https://$FLM_SVADDR/deviceinfo/receive/devices")
+	local _json_content="$(json_dump)"
+	_res=$(send_data_flashman "devices" "$_json_content")
+	
 	json_cleanup
 	json_load "$_res"
 	json_get_var _processed processed

--- a/files/usr/share/mqtt.sh
+++ b/files/usr/share/mqtt.sh
@@ -80,7 +80,7 @@ rawspeedtest)
 	if lock -n /tmp/set_speedtest.lock
 	then
 		log "MQTTMSG" "Starting raw speed test..."
-		run_speed_ondemand_raw_test "$2" "$3" "$4"
+		run_speed_ondemand_test "" "$2" "$3" "$4"
 		lock -u /tmp/set_speedtest.lock
 	fi
 	;;


### PR DESCRIPTION
- Changed the order to recover the traffic before exiting function.
- Sending empty speed reply in speed test.
- Merged speed test and speed test raw functions.
- Created a common function to send the results to the deviceinfo/receive endpoint in flashman.
- Changed curl calls to use the new common function.
- Remove hosts file in ping test.