### PR TITLE
Fixed wrong reached_destination.

### DIFF
--- a/files/usr/share/functions/api_functions.sh
+++ b/files/usr/share/functions/api_functions.sh
@@ -483,7 +483,7 @@ get_traceroute() {
 			local _hops="$(echo "$_traceroute" | grep -E -o '[0-9]*(\.[0-9]*){3}((  \*)*  [0-9]*\.[0-9]* ms)+')"
 
 			# The ip of what the last hop should be
-			local _last_ip="$(echo "$_traceroute" | grep -m 1 -Eo '[0-9]*(\.[0-9]*){3}')"
+			local _last_ip="$(echo "$_traceroute" | grep -m 1 -Eo '[0-9]*(\.[0-9]*){3}' | head -1)"
 			
 			# Find lines where there is more than 1 IP
 			local _blacklist_hops="$(echo "$_traceroute" | grep -E -o '[0-9]*(\.[0-9]*){3}.*[0-9]*(\.[0-9]*){3}')"


### PR DESCRIPTION
Fixed case where grep returns more than 1 occurrence even though -m 1 is present. This bug affected reached_destination value when testing IPs.